### PR TITLE
Replace loopback with Juggler for testing

### DIFF
--- a/lib/mqlight-connector.js
+++ b/lib/mqlight-connector.js
@@ -32,7 +32,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 
   var settings = dataSource.settings;
-  var connector = new MQLightConnector(settings);
+  var connector = new MQLightConnector({settings: {service: settings.service}});
 
   dataSource.connector = connector;
   dataSource.connector.dataSource = dataSource;
@@ -95,7 +95,7 @@ MQLightConnector.prototype.connect = function(cb) {
     debug('Connecting to MQ service: %s', self.settings.service);
   }
 
-  mqlight.createClient(self.settings, function(err, client) {
+  self.client = mqlight.createClient(self.settings, function(err, client) {
     if (err) {
       return cb && cb(err);
     }

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "mqlight": "^1.0.0"
   },
   "devDependencies": {
+    "bluebird": "^2.9.9",
     "eslint": "^1.10.3",
     "eslint-config-strongloop": "^1.0.2",
-    "loopback": "^2.28.0",
+    "loopback-datasource-juggler": "^2.50.0",
     "mocha": "^2.3.4",
     "rc": "^1.1.5",
     "should": "^8.1.1",
-    "sinon": "^1.17.2",
-    "bluebird": "^2.9.9"
+    "sinon": "^1.17.2"
   },
   "repository": {
     "type": "git",

--- a/test/mqlight.connection.test.js
+++ b/test/mqlight.connection.test.js
@@ -7,7 +7,8 @@
 process.env.NODE_ENV = 'test';
 require('./init.js');
 var assert = require('assert');
-var loopback = require('loopback');
+var connector = require('..');
+var DataSource = require('loopback-datasource-juggler').DataSource;
 
 var config;
 
@@ -16,18 +17,9 @@ before(function() {
 });
 
 describe('testConnection', function() {
-  it('should pass with valid settings', function(done) {
-    var ds = loopback.createDataSource(
-      {connector: require('../'), settings: config});
-
-    ds.on('connected', function(err) {
-      assert(!err, 'Should connect without err.');
-
-      ds.on('disconnected', function() {
-        done();
-      });
-
-      ds.disconnect();
-    });
+  it('should pass with valid settings', function() {
+    var ds = new DataSource(connector, config);
+    assert(ds.connected);
+    ds.disconnect();
   });
 });

--- a/test/mqlight.messaging.test.js
+++ b/test/mqlight.messaging.test.js
@@ -7,7 +7,8 @@
 
 process.env.NODE_ENV = 'test';
 require('./init.js');
-var loopback = require('loopback');
+var connector = require('..');
+var DataSource = require('loopback-datasource-juggler').DataSource;
 var assert = require('assert');
 
 var config;
@@ -17,67 +18,43 @@ var receiver;
 var receiverModel;
 var senderModel;
 
-before(function(done) {
+before(function() {
   config = global.config;
 
-  sender = loopback.createDataSource('mqlight',
-                {connector: require('../'), settings: config});
-
-  sender.on('connected', function(err) {
-    if (err) {
-      return done(new Error('Failed to connect to MQ Service to send'));
-    }
-
-    receiver = loopback.createDataSource('mqlight',
-                    {connector: require('../'), settings: config});
-
-    receiver.on('connected', function(err) {
-      if (err) {
-        return done(new Error('Failed to connect to MQ Service to receive'));
-      }
-
-      done();
-    });
-  });
+  sender = new DataSource(connector, config);
+  receiver = new DataSource(connector, config);
 });
 
-after(function(done) {
+after(function() {
   receiver.disconnect();
-  done();
 });
 
 describe('testMessages', function() {
   before(function(done) {
     receiverModel = receiver.createModel('receiverModel', {});
-
-    receiverModel.subscribe('public', function(error) {
-      if (error) {
-        return done(error);
-      }
-
+    receiverModel.subscribe('public', function(err) {
+      if (err) return done(err);
       done();
     });
-
     senderModel = sender.createModel('senderModel', {});
   });
 
-  after(function(done) {
+  after(function() {
     receiverModel.unsubscribe('public');
     sender.disconnect();
-    done();
   });
 
   it('test create function', function(done) {
-    receiverModel.find(0, function(data) {
-      assert.equal(data, 'Create Message');
-      done();
-    });
-
-    senderModel.create({topic: 'public', message: 'Create Message'},
-      function(error) {
-        assert(!error, 'Should not error on sending a message');
-        done(error);
+    senderModel.create({
+      topic: 'public',
+      message: 'Create Message',
+    }, function(err) {
+      if (err) return done(err);
+      receiverModel.find(0, function(data) {
+        assert.equal(data, 'Create Message');
+        done();
       });
+    });
   });
 
   it('test update function', function(done) {


### PR DESCRIPTION
Tests should be using Juggler from the start. This is also needed to separate
2.x and 3.x Juggler versions for testing/CI.

@bajtos PTAL
cc @qpresley 

Connect to strongloop/loopback#2724