### PR TITLE
Allow disabled user/pass auth for tests

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -8,8 +8,13 @@ module.exports = require('should');
 var config = {
   user: process.env.MQ_USERNAME,
   password: process.env.MQ_PASSWORD,
-  service: process.env.MQ_CONNECTION_URI,
+  service: process.env.MQ_CONNECTION_URI || 'amqp://localhost:5672',
 };
+// allow disabled username/password authentication
+if (!config.user)
+  delete config.user;
+if (!config.password)
+  delete config.password;
 
 global.config = config;
 


### PR DESCRIPTION
MQ Light supports disabled username/password authentication. Since we assign
environment variables to the test configurations, they default to empty string
('') and causes the connector to fail authentication. Deleting the values
completely corrects this behaviour.

cc @bajtos 