### PR TITLE
Refactor and enable tests (#22)

### DIFF
--- a/intl/en/messages.json
+++ b/intl/en/messages.json
@@ -1,0 +1,3 @@
+{
+  "9e0741235a886f59597b0b93eda6c192": "Invalid settings object"
+}

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-mqlight
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var path = require('path');
+var SG = require('strong-globalize');
+
+SG.SetRootDir(path.join(__dirname, '..'), {autonomousMsgLoading: 'all'});
+module.exports = SG();

--- a/lib/mqlight-connector.js
+++ b/lib/mqlight-connector.js
@@ -4,16 +4,23 @@
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
 'use strict';
+var g = require('./globalize');
+var semver = require('semver');
 
 // Require the underlying MQLight driver
-var mqlight = require('mqlight');
+var runningOnNode6 = semver.satisfies(process.version, '^6.x.x');
+if (!runningOnNode6)
+  var mqlight = require('mqlight');
 
 // Require the debug module with a pattern of loopback:connector:connectorName
 var debug = require('debug')('loopback:connector:mqlight');
 
 // Require events as this module will emit events on reception of messages
 // from the Message Queue.
-var EventEmitter = require('events');
+var runningOnNode10 = semver.satisfies(process.version, '^0.10.x');
+var EventEmitter = runningOnNode10 ?
+  require('events').EventEmitter :
+  require('events');
 
 // Require util so we can inherit the EventEmitter class
 var util = require('util');
@@ -28,6 +35,9 @@ var MQLightResource = require('./mqlight-model.js');
  * @param {Function} [callback] The callback function
  */
 exports.initialize = function initializeDataSource(dataSource, callback) {
+  if (runningOnNode6)
+    callback(new Error('This connector does not support Node 6'));
+
   // var self = this;
   if (!dataSource.settings) {
     return callback(new Error('Invalid settings object'));
@@ -39,9 +49,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   dataSource.connector = connector;
   dataSource.connector.dataSource = dataSource;
 
-  connector.connect();
-
-  callback();
+  connector.connect(callback);
 };
 
 function MQLightConnector(config) {

--- a/package.json
+++ b/package.json
@@ -13,24 +13,25 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha",
+    "test": "mocha --timeout 10000 test/integration",
     "posttest": "npm run lint"
   },
   "dependencies": {
     "async": "^1.5.0",
     "debug": "^2.2.0",
     "loopback-connector": "^2.3.0",
-    "mqlight": "^1.0.0"
+    "mqlight": "^1.0.0",
+    "semver": "^5.3.0",
+    "strong-globalize": "^2.7.0"
   },
   "devDependencies": {
-    "bluebird": "^2.9.9",
+    "chai": "^3.5.0",
+    "dirty-chai": "^1.2.2",
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
     "loopback-datasource-juggler": "^2.50.0",
     "mocha": "^2.3.4",
-    "rc": "^1.1.5",
-    "should": "^8.1.1",
-    "sinon": "^1.17.2"
+    "rc": "^1.1.5"
   },
   "repository": {
     "type": "git",

--- a/test/describe.js
+++ b/test/describe.js
@@ -1,0 +1,6 @@
+'use strict';
+var semver = require('semver');
+
+// Skip all tests on Node 6 because MQLight does not support it
+var runningOnNode6 = semver.satisfies(process.version, '^6.x.x');
+module.exports = runningOnNode6 ? describe.skip.bind(describe) : describe;

--- a/test/init.js
+++ b/test/init.js
@@ -5,8 +5,13 @@
 
 'use strict';
 
-module.exports = require('should');
+// assertion lib
+var chai = require('chai');
+var dirtyChai = require('dirty-chai');
+chai.use(dirtyChai);
+global.expect = chai.expect;
 
+// database configs
 var config = {
   user: process.env.MQ_USERNAME,
   password: process.env.MQ_PASSWORD,
@@ -17,12 +22,4 @@ if (!config.user)
   delete config.user;
 if (!config.password)
   delete config.password;
-
 global.config = config;
-
-// global.getDataSource = global.getSchema = function(options) {
-//   var db = new DataSource(require('../'), config);
-//   return db;
-// };
-
-global.sinon = require('sinon');

--- a/test/integration/connection.js
+++ b/test/integration/connection.js
@@ -1,0 +1,20 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-mqlight
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+var connector = require('../..');
+var DataSource = require('loopback-datasource-juggler').DataSource;
+var describe = require('../describe');
+
+describe('connection', function() {
+  it('connects with valid settings', function(done) {
+    var ds = new DataSource(connector, config);
+    ds.on('started', function() {
+      expect(ds.connected).to.be.true();
+      ds.disconnect();
+      done();
+    });
+  });
+});

--- a/test/integration/messaging.js
+++ b/test/integration/messaging.js
@@ -1,0 +1,74 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-mqlight
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+var connector = require('../..');
+var DataSource = require('loopback-datasource-juggler').DataSource;
+var describe = require('../describe');
+
+describe('messaging', function() {
+  var sender, receiver, senderModel, receiverModel;
+  beforeEach(setupSender);
+  beforeEach(setupReceiver);
+  afterEach(teardownSender);
+  afterEach(teardownReceiver);
+
+  it('creates a message', function(done) {
+    senderModel.create({topic: 'public', message: 'A create message'},
+    function(err) {
+      if (err) return done(err);
+      receiverModel.find(0, function(msg) {
+        expect(msg).to.equal('A create message');
+        done();
+      });
+    });
+  });
+
+  it('updates a message', function(done) {
+    senderModel.update({topic: 'public', message: 'An update message'},
+    function(err) {
+      if (err) return done(err);
+      receiverModel.find(0, function(msg) {
+        expect(msg).to.equal('An update message');
+        done();
+      });
+    });
+  });
+
+  it('deletes a message', function(done) {
+    senderModel.delete({topic: 'public', message: 'A delete message'},
+    function(err) {
+      if (err) return done(err);
+      receiverModel.find(0, function(msg) {
+        expect(msg).to.equal('A delete message');
+        done();
+      });
+    });
+  });
+
+  function setupSender(done) {
+    sender = new DataSource(connector, config);
+    sender.on('started', function() {
+      senderModel = sender.createModel('senderModel', {});
+      done();
+    });
+  }
+  function setupReceiver(done) {
+    receiver = new DataSource(connector, config);
+    receiver.on('started', function() {
+      receiverModel = receiver.createModel('receiverModel', {});
+      receiverModel.subscribe('public');
+      done();
+    });
+  }
+  function teardownSender() {
+    if (sender.connected)
+      sender.disconnect();
+  }
+  function teardownReceiver() {
+    if (receiver.connected)
+      receiver.disconnect();
+  }
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/init


### PR DESCRIPTION
- Enable tests by removing test/describe.js
- Move tests into test/integration
- Modify initialize to trigger callback correctly after connecting
  successfully (was causing tests to hang)
- Refactor test initialization to use expect and config globally
- Refactor suites to setup/teardown tests properly
- Remove should in favour of chai/dirty-chai
- Remove unused devdeps blueblird and sinon
- Add semver to check for node 0.10 syntax for inheriting EventEmitter
- Increase timeout to 10000ms
- Skip tests on Node version 6 (not supported by underlying driver
  mqlight
- Fail the connector gracefully on initalize via callback when Node 6 is
  used (instead of throwing on require which causes the app the crash)

Backport of #22 

cc @qpresley 